### PR TITLE
Added match data tab

### DIFF
--- a/assets/wesoccer.css
+++ b/assets/wesoccer.css
@@ -214,23 +214,24 @@ body {
 ------>      TABLES     <------
 ===============================
 */
+
 table {
     font-variant-numeric: lining-nums tabular-nums;
     border-collapse: collapse;
-  }
-  
-  tr {
+}
+
+tr {
     border-bottom: 1px solid #ecf0f1;
-  }
-  
-  td, th {
+}
+
+td,
+th {
     padding: 0.5em 0;
     line-height: 1.05rem;
     vertical-align: middle;
     text-align: center;
     text-overflow: ellipsis;
-  }
-  
+}
 
 /*
 ==================================
@@ -997,7 +998,6 @@ li a {
     border-bottom: 1px solid #ecf0f1;
 }
 
-
 /*
   ===============================
   --------> CARD EVENTS <-------
@@ -1539,14 +1539,26 @@ teams__heading {
   ===============================
   ---> MAIN THEME OVERRIDES <----
   ===============================
-  */
+*/
 
-  @media screen and (min-width: 768px) {
+.plugin__link {
+    text-decoration: none !important;
+    color: white;
+}
+
+.plugin-dropdown__link {
+    text-decoration: none !important;
+    color: black;
+}
+
+#matchesContainer #pageControls .tabControls ul li {
+    padding: 0 !important;
+}
+
+@media screen and (min-width: 768px) {
     #matchesContainer #pageControls .tabControls ul li {
-        max-width: 25%!important;
-        padding: 0!important;
+        max-width: 25% !important;
     }
-
     #matchesContainer #pageControls .tabControls ul li a {
         padding: 20px 15px;
     }

--- a/assets/wesoccer.css
+++ b/assets/wesoccer.css
@@ -1541,8 +1541,7 @@ teams__heading {
   ===============================
   */
 
-  @media screen and (min-width: 1024px) {
-
+  @media screen and (min-width: 768px) {
     #matchesContainer #pageControls .tabControls ul li {
         max-width: 25%!important;
         padding: 0!important;
@@ -1551,5 +1550,4 @@ teams__heading {
     #matchesContainer #pageControls .tabControls ul li a {
         padding: 20px 15px;
     }
-
 }

--- a/assets/wesoccer.css
+++ b/assets/wesoccer.css
@@ -1541,10 +1541,15 @@ teams__heading {
   ===============================
   */
 
-@media screen and (min-width: 1024px) {
+  @media screen and (min-width: 1024px) {
 
     #matchesContainer #pageControls .tabControls ul li {
         max-width: 25%!important;
+        padding: 0!important;
+    }
+
+    #matchesContainer #pageControls .tabControls ul li a {
+        padding: 20px 15px;
     }
 
 }

--- a/readme.txt
+++ b/readme.txt
@@ -14,3 +14,49 @@ in wp-content/plugins/wesoccer, run 'composer install'
 link to a fixture with events: {your SWFL root address}/wesoccer-fixture/?id=1961
 
 link to a date with fixtures in 3 competitions: {your SWFL root address}/wesoccer-competition/?date=2018-09-15
+
+
+/* ADDING MATCH DATA TAB TO A TEMPLATE */
+
+Paste this snippet at the end of 
+
+themes/website-womenspremierleague/includes/css/main-stylesheet.css 
+
+/*
+  ===============================
+  ---> MAIN THEME OVERRIDES <----
+  ===============================
+  */
+
+  #matchesContainer #pageControls .tabControls ul li:last-child {
+    padding: 0;
+  }
+
+  #matchesContainer #pageControls .tabControls ul li a:last-child {
+    padding: 20px 15px;
+  }
+
+  #matchesContainer #pageControls .tabControls ul li a {
+    text-decoration: none!important;
+    color: black!important;
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  @media screen and (min-width: 1024px) {
+
+    #matchesContainer #pageControls .tabControls ul li {
+        width: 25%!important;
+        
+    }
+
+}
+
+and add a tab to 
+
+themes/website-womenspremierleague/includes/template-parts/view-fixtures-results.php
+
+on line 34
+
+<li data-tab-child="matchDataTab" data-label="Match Data"><a href="/wesoccer-competition/?date=2018-09-15">Match Data</a></li>

--- a/readme.txt
+++ b/readme.txt
@@ -44,14 +44,12 @@ themes/website-womenspremierleague/includes/css/main-stylesheet.css
     height: 100%;
   }
 
-  @media screen and (min-width: 1024px) {
-
+  @media screen and (min-width: 768px) {
     #matchesContainer #pageControls .tabControls ul li {
-        width: 25%!important;
-        
+      max-width: 25%!important;
     }
+  }
 
-}
 
 and add a tab to 
 

--- a/wesoccer-competition-template.php
+++ b/wesoccer-competition-template.php
@@ -21,7 +21,7 @@ $data['fixtures'] = $grouped_fixtures;
         <div class="leagueSwitch">
             <div class="js-dropdown">
                 <div class="activeItem">
-                    <span><a href="<?php echo home_url() ?>/wesoccer-competition/?date=2018-09-15?>">TEST</a><i class="material-icons">&#xE313;</i></span>
+                    <span><a href="<?php echo home_url() ?>/wesoccer-competition/?date=2018-09-15">TEST</a><i class="material-icons">&#xE313;</i></span>
                 </div>
                 <div class="active">
                     <ul>

--- a/wesoccer-competition-template.php
+++ b/wesoccer-competition-template.php
@@ -77,7 +77,7 @@ $data['fixtures'] = $grouped_fixtures;
                                 <?php foreach ($data['dates'] AS $date): ?>
 
                                     <li class='timeline__listitem'>
-                                        <a class='timeline__link' href='#'><?php echo $date['name'] ?><?php echo $date['friendly_date'] ?></a>
+                                        <a class='timeline__link' href='<?php echo home_url() ?>/wesoccer-competition/?date=<?php echo $date['link_date']; ?>'><?php echo $date['name'] ?><?php echo $date['friendly_date'] ?></a>
                                     </li>
 
                                 <?php endforeach; ?>

--- a/wesoccer-competition-template.php
+++ b/wesoccer-competition-template.php
@@ -51,147 +51,150 @@ $data['fixtures'] = $grouped_fixtures;
 
 <div class="container">
 
+    <div class="col-12">
+        <div class="tabTitle">
+            <h3>Match Data</h3>
+        </div>
+    </div>
+
+
 <!-- 
      STYLES AND MARKUP FROM WESOCCER
 -->
-<section class="fixtures">
-    <header>
-        <h2 class="page__heading">Match Data</h2>
-    </header>
-        <!-- TIMELINE -->
-        <div class="fx-timeline__wrapper">
-            <!-- Left arrow  -->
-            <button id="prev_btn" class="timeline__btn" type="button" name="button">
-                <i class="fa fa-chevron-left"></i>
-            </button>
+        <section class="fixtures">
+            <!-- TIMELINE -->
+            <div class="fx-timeline__wrapper">
+                <!-- Left arrow  -->
+                <button id="prev_btn" class="timeline__btn" type="button" name="button">
+                    <i class="fa fa-chevron-left"></i>
+                </button>
 
-            <div id="timeline" class="timeline">
-                <div class="timeline__lists">
-                    <div class="timeline__group">
-                        <ul id="list" class="timeline__list margin--clear">
+                <div id="timeline" class="timeline">
+                    <div class="timeline__lists">
+                        <div class="timeline__group">
+                            <ul id="list" class="timeline__list margin--clear">
 
-                            <?php foreach ($data['dates'] AS $date): ?>
+                                <?php foreach ($data['dates'] AS $date): ?>
 
-                                <li class='timeline__listitem'>
-                                    <a class='timeline__link' href='#'><?php echo $date['name'] ?><?php echo $date['friendly_date'] ?></a>
-                                </li>
+                                    <li class='timeline__listitem'>
+                                        <a class='timeline__link' href='#'><?php echo $date['name'] ?><?php echo $date['friendly_date'] ?></a>
+                                    </li>
 
-                            <?php endforeach; ?>
-                        </ul>
+                                <?php endforeach; ?>
+                            </ul>
+                        </div>
                     </div>
                 </div>
+
+                <!-- Right arrow  -->
+                <button id="next_btn" class="timeline__btn" type="button" name="button">
+                    <i class="fa fa-chevron-right"></i>
+                </button>
             </div>
 
-            <!-- Right arrow  -->
-            <button id="next_btn" class="timeline__btn" type="button" name="button">
-                <i class="fa fa-chevron-right"></i>
-            </button>
-        </div>
+            <!-- FIXTURES LIST -->
+            <div id='fixtures-container' class="fx__content">
+                <?php foreach ($data['fixtures'] AS $competition_name => $fixtures): ?>
 
-        <!-- FIXTURES LIST -->
-        <div id='fixtures-container' class="fx__content">
-            <?php foreach ($data['fixtures'] AS $competition_name => $fixtures): ?>
+                <section class="fx-league">
+                    <h4 class="list__heading fx-league__heading"><?php echo $competition_name; ?></h4>
+                    <?php foreach ($fixtures AS $fixture): ?>
 
-            <section class="fx-league">
-                <h4 class="list__heading fx-league__heading"><?php echo $competition_name; ?></h4>
-                <?php foreach ($fixtures AS $fixture): ?>
+                    <div id='fixture--container' class="flex__wrapper--lg-desktop">
+                        <ul class="fx-league__list">
 
-                <div id='fixture--container' class="flex__wrapper--lg-desktop">
-                    <ul class="fx-league__list">
+                            <!-- Fixture row-->
+                            <li class="fx-league__listitem">
+                                <a class="fx-league__link" href="<?php echo home_url() ?>/wesoccer-fixture/?id=<?php echo $fixture['id']; ?>">
 
-                        <!-- Fixture row-->
-                        <li class="fx-league__listitem">
-                            <a class="fx-league__link" href="<?php echo home_url() ?>/wesoccer-fixture/?id=<?php echo $fixture['id']; ?>">
+                                    <article class="fx-league__fixture">
+                                        <div class="fx-league__fixture-wrapper">
 
-                                <article class="fx-league__fixture">
-                                    <div class="fx-league__fixture-wrapper">
-
-                                        <!--Kick-off time -->
-                                        <span class="kickoff_time--fixture">
-                                            <?php echo $fixture['start_time']['hours'] ?>:<?php echo $fixture['start_time']['minutes'] ?>
-                                        </span>
-
-                                       
-                                        <!-- Home team block -->
-                                        <div class="fixture__team">
-                                            <div class="fixture__team--home">
-                                                <span class="fixture__team-name"><?php echo $fixture['home_team']['name'] ?></span>
-                                                <abbr class="fixture__team-shortname"><?php echo $fixture['home_team']['name'] ?></abbr>
-                                                <div class="fixture__emblem">
-                                                    <i class="material-icons">
-                                                        insert_emoticon
-                                                    </i>
-                                                </div>
-                                            </div>
-                                        </div>
-
-                                        <!-- Score block -->
-                                        <div class="fixture__block">
-                                            <div class="fixture__box">
-                                                <span class="fixture__num ">
-                                                    <span><?php echo $fixture['home_team']['goals'] ?></span>
-                                                </span>
-
-                                                <span class="fixture__separator">&ndash;</span>
-
-                                                <span class="fixture__num ">
-                                                    <span><?php echo $fixture['away_team']['goals'] ?></span>
-                                                </span>
-
-                                            </div>
-                                            <div class="penalties__box">
-                                                <div class="penalties">
-                                                    <span class="penalties__num ">
-                                                         <span><?php echo $fixture['home_team']['penalties'] ?></span>
-                                                    </span>
-
-                                                    <span class="fixture__note">PENS</span>
-                                                    <span class="penalties__num ">
-                                                        <span><?php echo $fixture['away_team']['penalties'] ?></span>
-                                                    </span>
-
-                                                </div>
-                                            </div>
-                                        </div>
-
-                                        <!-- Away team block -->
-                                        <div class="fixture__team">
-                                            <div class="fixture__team--away">
-                                                <div class="fixture__emblem">
-                                                    <i class="material-icons">
-                                                        insert_emoticon
-                                                    </i>
-                                                </div>
-                                                <span class="fixture__team-name"><?php echo $fixture['away_team']['name'] ?></span>
-                                                <abbr class="fixture__team-shortname"><?php echo $fixture['away_team']['name'] ?></abbr>
-                                            </div>
-                                        </div>
-
-                                        <!-- Game time -->
-                                        <span class="game_time--fixture">
-                                            <span>
-                                                <?php echo $fixture['minutes'] ?>&prime;
+                                            <!--Kick-off time -->
+                                            <span class="kickoff_time--fixture">
+                                                <?php echo $fixture['start_time']['hours'] ?>:<?php echo $fixture['start_time']['minutes'] ?>
                                             </span>
-                                        </span>
 
-                                    </div>
-                                </article>
-                            </a>
-                        </li>
-                        <!-- End of fixture row  -->
+                                            <!-- Home team block -->
+                                            <div class="fixture__team">
+                                                <div class="fixture__team--home">
+                                                    <span class="fixture__team-name"><?php echo $fixture['home_team']['name'] ?></span>
+                                                    <abbr class="fixture__team-shortname"><?php echo $fixture['home_team']['name'] ?></abbr>
+                                                    <div class="fixture__emblem">
+                                                        <i class="material-icons">
+                                                            insert_emoticon
+                                                        </i>
+                                                    </div>
+                                                </div>
+                                            </div>
 
-                    </ul>
+                                            <!-- Score block -->
+                                            <div class="fixture__block">
+                                                <div class="fixture__box">
+                                                    <span class="fixture__num ">
+                                                        <span><?php echo $fixture['home_team']['goals'] ?></span>
+                                                    </span>
+
+                                                    <span class="fixture__separator">&ndash;</span>
+
+                                                    <span class="fixture__num ">
+                                                        <span><?php echo $fixture['away_team']['goals'] ?></span>
+                                                    </span>
+
+                                                </div>
+                                                    <div class="penalties__box">
+                                                        <div class="penalties">
+
+                                                            <span class="penalties__num ">
+                                                                <span><?php echo $fixture['home_team']['penalties'] ?></span>
+                                                            </span>
+
+                                                            <span class="fixture__note">PENS</span>
+
+                                                            <span class="penalties__num ">
+                                                                <span><?php echo $fixture['away_team']['penalties'] ?></span>
+                                                            </span>
+
+                                                        </div>
+                                                    </div>
+                                                </div>
+
+                                                <!-- Away team block -->
+                                                <div class="fixture__team">
+                                                    <div class="fixture__team--away">
+                                                        <div class="fixture__emblem">
+                                                            <i class="material-icons">
+                                                                insert_emoticon
+                                                            </i>
+                                                        </div>
+                                                        <span class="fixture__team-name"><?php echo $fixture['away_team']['name'] ?></span>
+                                                        <abbr class="fixture__team-shortname"><?php echo $fixture['away_team']['name'] ?></abbr>
+                                                    </div>
+                                                </div>
+
+                                                <!-- Game time -->
+                                                <span class="game_time--fixture">
+                                                    <span>
+                                                        <?php echo $fixture['minutes'] ?>&prime;
+                                                    </span>
+                                                </span>
+
+                                            </div>
+                                        </article>
+                                    </a>
+                                </li>
+                            <!-- End of fixture row  -->
+                            </ul>
+                        </div>
+                    <?php endforeach; ?>
+                    </section>
+
                 </div>
-                <?php endforeach; ?>
-            </section>
+            <?php endforeach; ?>
 
-        </div>
-        <?php endforeach; ?>
-
-    </div>   
-</section>
-</div>
-
+            </div>   
+        </section>
+    </div>
 </div>
 
 <!-- 

--- a/wesoccer-competition-template.php
+++ b/wesoccer-competition-template.php
@@ -62,9 +62,7 @@ $data['fixtures'] = $grouped_fixtures;
         <div class="fx-timeline__wrapper">
             <!-- Left arrow  -->
             <button id="prev_btn" class="timeline__btn" type="button" name="button">
-            <i class="material-icons md-48">
-                keyboard_arrow_left
-            </i>
+                <i class="fa fa-chevron-left"></i>
             </button>
 
             <div id="timeline" class="timeline">
@@ -86,9 +84,7 @@ $data['fixtures'] = $grouped_fixtures;
 
             <!-- Right arrow  -->
             <button id="next_btn" class="timeline__btn" type="button" name="button">
-            <i class="material-icons md-48">
-                keyboard_arrow_right
-            </i>
+                <i class="fa fa-chevron-right"></i>
             </button>
         </div>
 

--- a/wesoccer-competition-template.php
+++ b/wesoccer-competition-template.php
@@ -21,12 +21,12 @@ $data['fixtures'] = $grouped_fixtures;
         <div class="leagueSwitch">
             <div class="js-dropdown">
                 <div class="activeItem">
-                    <span><a href="<?php echo home_url() ?>/wesoccer-competition/?date=2018-09-15">TEST</a><i class="material-icons">&#xE313;</i></span>
+                    <span><a class="plugin__link" href="<?php echo home_url() ?>/wesoccer-competition/?date=2018-09-15">TEST</a><i class="material-icons">&#xE313;</i></span>
                 </div>
                 <div class="active">
                     <ul>
-                        <a href="/fixtures-results"><li data-leagueid="93" data-label="SWPL 1">SWPL 1</li></a>
-                        <a href="/fixtures-results"><li data-leagueid="471" data-label="SWPL 2">SWPL 2</li></a>
+                        <li data-leagueid="93" data-label="SWPL 1"><a class="plugin-dropdown__link" href="/fixtures-results">SWPL 1</a></li>
+                        <li data-leagueid="471" data-label="SWPL 2"><a class="plugin-dropdown__link" href="/fixtures-results">SWPL 2</a></li>>
                     </ul>
                 </div>
             </div>

--- a/wesoccer-fixture-template.php
+++ b/wesoccer-fixture-template.php
@@ -20,12 +20,12 @@ $events = $data['events'];
             <div class="leagueSwitch">
                 <div class="js-dropdown">
                     <div class="activeItem">
-                        <span><a href="<?php echo home_url() ?>/wesoccer-competition/?date=2018-09-15"><abbr><?php echo $fixture['competition_short_name'] ?></abbr></a><i class="material-icons">&#xE313;</i></span>
+                        <span><a class="plugin__link" href="<?php echo home_url() ?>/wesoccer-competition/?date=2018-09-15"><abbr><?php echo $fixture['competition_short_name'] ?></abbr></a><i class="material-icons">&#xE313;</i></span>
                     </div>
                     <div class="active">
                         <ul>
-                            <a href="/fixtures-results"><li data-leagueid="93" data-label="SWPL 1">SWPL 1</li></a>
-                            <a href="/fixtures-results"><li data-leagueid="471" data-label="SWPL 2">SWPL 2</li></a>
+                            <li data-leagueid="93" data-label="SWPL 1"><a class="plugin-dropdown__link" href="/fixtures-results">SWPL 1</a></li>
+                            <li data-leagueid="471" data-label="SWPL 2"><a class="plugin-dropdown__link" href="/fixtures-results">SWPL 2</a></li>
                         </ul>
                     </div>
                 </div>

--- a/wesoccer-fixture-template.php
+++ b/wesoccer-fixture-template.php
@@ -118,7 +118,7 @@ $events = $data['events'];
                                 <span class="card__player"><?php echo $event['card_code'] ?> <?php echo $event['card_reason'] ?></span>
                                 </span>
                                 <span class="card__ico-box">
-                                    <span class="card__ico card__ico--yellow" style="background-color:#FFFFFF">
+                                    <span class="card__ico" style="background-color:#FFFFFF; border-color:<?php echo strtolower($event['card_type']) ?>;">
                                         <span class="card__player-num" style="background-color:#FFFFFF"><?php echo $event['player']['shirt_number'] ?></span>
                                     </span>
                                 </span>
@@ -147,7 +147,7 @@ $events = $data['events'];
                         <td colspan="2">
                             <div class="card__box card__box--left">
                                 <span class="card__ico-box">
-                                    <span class="card__ico card__ico--yellow" style="background-color:#FFFFFF">
+                                    <span class="card__ico" style="background-color:#FFFFFF; border-color:<?php echo strtolower($event['card_type']) ?>;">
                                         <span class="card__player-num"><?php echo $event['player']['shirt_number'] ?></span>
                                     </span>
                                 </span>


### PR DESCRIPTION
/* ADDING MATCH DATA TAB TO A TEMPLATE */

Paste this snippet at the end of 

themes/website-womenspremierleague/includes/css/main-stylesheet.css 

```
/*
  ===============================
  ---> MAIN THEME OVERRIDES <----
  ===============================
  */

  #matchesContainer #pageControls .tabControls ul li:last-child {
    padding: 0;
  }

  #matchesContainer #pageControls .tabControls ul li a:last-child {
    padding: 20px 15px;
  }

  #matchesContainer #pageControls .tabControls ul li a {
    text-decoration: none!important;
    color: black!important;
    display: block;
    width: 100%;
    height: 100%;
  }

  @media screen and (min-width: 768px) {
    #matchesContainer #pageControls .tabControls ul li {
      max-width: 25%!important;
    }
  }
```


and add a tab to 

themes/website-womenspremierleague/includes/template-parts/view-fixtures-results.php

on line 34

`<li data-tab-child="matchDataTab" data-label="Match Data"><a href="/wesoccer-competition/?date=2018-09-15">Match Data</a></li>`